### PR TITLE
Support custom sleep time

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -17,6 +17,12 @@ r"^\#\# \[\d{1,}[.]\d{1,}[.]\d{1,}\] \- \d{4}\-\d{2}-\d{2}$"
 -->
 
 ## Released
+## [0.2.0] - 2022-11-01
+### Added
+- Add [`read_device_info_registers`](examples/read_device_info_registers.py)
+  script to read Modbus device data
+- Specify sleep time in seconds between two modbus operations
+
 ## [0.1.0] - 2022-09-25
 ### Added
 - This changelog file
@@ -34,8 +40,9 @@ r"^\#\# \[\d{1,}[.]\d{1,}[.]\d{1,}\] \- \d{4}\-\d{2}-\d{2}$"
 - [`tox.ini`](tox.ini) file using `nose2` and `coverage` create coverage report
 
 <!-- Links -->
-[Unreleased]: https://github.com/brainelectronics/be-modbus-wrapper/compare/0.1.0...develop
+[Unreleased]: https://github.com/brainelectronics/be-modbus-wrapper/compare/0.2.0...main
 
+[0.2.0]: https://github.com/brainelectronics/be-modbus-wrapper/tree/0.2.0
 [0.1.0]: https://github.com/brainelectronics/be-modbus-wrapper/tree/0.1.0
 
 <!--

--- a/examples/read_device_info_registers.py
+++ b/examples/read_device_info_registers.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+# -*- coding: UTF-8 -*-
+"""Read Modbus device register informations based on JSON registers file"""
+#
+#  @author       Jonas Scharpf (info@brainelectronics.de) brainelectronics
+#  @file         read_device_info_registers.py
+#  @date         November, 2022
+#  @version      0.5.0
+#  @brief        Read all registers via RTU modbus or external IP
+#
+#  @required     pymodbus 2.3.0 or higher
+#
+#  @usage
+#  python3 read_device_info_registers.py \
+#   --file=example/modbusRegisters.json \
+#   --connection=rtu \
+#   --address=/dev/tty.wchusbserial1420 \
+#   --unit=10 \
+#   --baudrate=19200 \
+#   --print \
+#   --pretty \
+#   --save \
+#   --output info.json \
+#   -v4 -d
+#
+#  python3 read_device_info_registers.py \
+#   --file=example/modbusRegisters-phoenix.json \
+#   --connection=tcp \
+#   --address=192.168.0.8 \
+#   --port=180 \
+#   --print \
+#   --pretty \
+#   --save \
+#   --output info.json \
+#   -v4 -d
+#
+#  optional arguments:
+#   -h, --help
+#
+#   -a, --address   Address to connect to, like 192.168.0.8 or
+#                   /dev/tty.SLAB_USBtoUART
+#   --baudrate      Baudrate of RTU connection
+#   -c, --connection    Type of Modbus connection, ['tcp', 'rtu']
+#   -f, --file      Path to Modbus registers file
+#   -o, --output    Path to output file containing info
+#   -p, --port      Port of connection, not required for RTU Serial
+#   --pretty        Print collected info to stdout in human readable format
+#   --print         Print collected (JSON) info to stdout
+#   -s, --save      Save collected informations to file specified with
+#                   '--output' or '-o'
+#   --sleep         Time between two requests in seconds
+#   -u, --unit      Unit of connection
+#                   Tobi Test 1, Serial 10, Phoenix 180, ESP 255
+#   --validate      Validate received data with expected data
+#
+#   -d, --debug     Flag, Output logger messages to stderr (default: False)
+#   -v, --verbose   Verbosity level (default: None), sets debug flag to True
+#                   '-v3' or '-vvvv' == INFO
+#
+# ----------------------------------------------------------------------------
+
+__author__ = "Jonas Scharpf"
+__copyright__ = "Copyright by brainelectronics, ALL RIGHTS RESERVED"
+__credits__ = ["Jonas Scharpf"]
+__version__ = "0.5.0"
+__maintainer__ = "Jonas Scharpf"
+__email__ = "info@brainelectronics.de"
+__status__ = "Beta"
+
+import argparse
+import json
+
+# custom imports
+from be_helpers import ModuleHelper
+from be_modbus_wrapper import ModbusWrapper
+
+
+def parse_arguments() -> argparse.Namespace:
+    """
+    Parse CLI arguments.
+
+    :raise  argparse.ArgumentError
+    :return: argparse object
+    """
+    parser = argparse.ArgumentParser(description="""
+    Read Modbus register
+    """, formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+
+    # default arguments
+    parser.add_argument('-d', '--debug',
+                        action='store_true',
+                        help='Output logger messages to stderr')
+    parser.add_argument('-v',
+                        default=0,
+                        action='count',
+                        dest='verbose',
+                        help='Set level of verbosity')
+    parser.add_argument('--verbose',
+                        nargs='?',
+                        type=int,
+                        dest='verbose',
+                        help='Set level of verbosity')
+
+    # specific arguments
+    parser.add_argument('-a',
+                        '--address',
+                        help=('Address of connection, like 192.168.0.8 or '
+                              '/dev/tty.SLAB_USBtoUART'),
+                        nargs='?',
+                        required=True)
+
+    parser.add_argument('--baudrate',
+                        help='Baudrate of RTU connection',
+                        default=9600,
+                        type=int,
+                        required=False)
+
+    parser.add_argument('-c',
+                        '--connection',
+                        help='Type of Modbus connection',
+                        nargs='?',
+                        default="tcp",
+                        choices=['tcp', 'rtu'],
+                        required=True)
+
+    parser.add_argument('-f',
+                        '--file',
+                        help='Path to Modbus registers file',
+                        nargs='?',
+                        default="modbusRegisters.json",
+                        type=lambda x: ModuleHelper.parser_valid_file(parser,
+                                                                      x),
+                        required=True)
+
+    parser.add_argument('-o', '--output',
+                        dest='output_file',
+                        required=False,
+                        help='Path to output file containing info')
+
+    parser.add_argument('--pretty',
+                        dest='print_pretty',
+                        action='store_true',
+                        help='Print collected info to stdout in human readable'
+                        'format')
+
+    parser.add_argument('--print',
+                        dest='print_result',
+                        action='store_true',
+                        help='Print collected (JSON) info to stdout')
+
+    parser.add_argument('-p',
+                        '--port',
+                        help='Port of connection, not required for RTU Serial',
+                        default=502,
+                        type=int,
+                        required=False)
+
+    parser.add_argument('-s', '--save',
+                        dest='save_info',
+                        action='store_true',
+                        help='Save collected informations to file specified '
+                        'with --output or -o')
+
+    parser.add_argument('--sleep',
+                        dest='sleep_time',
+                        help='Time between two requests in seconds',
+                        default=0,
+                        type=int,
+                        required=False)
+
+    parser.add_argument('-u',
+                        '--unit',
+                        help=('Unit of connection, '
+                              'Phoenix 180, Tobi Test 1, ESP 255, Serial 10'),
+                        default=180,
+                        type=int,
+                        required=False)
+
+    parser.add_argument('--validate',
+                        help='Validate received data with expected data',
+                        required=False,
+                        action='store_true')
+
+    parsed_args = parser.parse_args()
+
+    return parsed_args
+
+
+if __name__ == "__main__":
+    helper = ModuleHelper(quiet=True)
+
+    logger = helper.create_logger(__name__)
+    register_logger = helper.create_logger("Register Logger")
+
+    # parse CLI arguments
+    args = parse_arguments()
+
+    # set verbose level based on user setting
+    helper.set_logger_verbose_level(logger=logger,
+                                    verbose_level=args.verbose,
+                                    debug_output=args.debug)
+    helper.set_logger_verbose_level(logger=register_logger,
+                                    verbose_level=args.verbose,
+                                    debug_output=args.debug)
+
+    # log the provided arguments
+    logger.debug(args)
+
+    # take CLI parameters
+    port = args.port
+    unit = args.unit
+    baudrate = args.baudrate
+    output_file = args.output_file
+    save_info = args.save_info
+    sleep_time = args.sleep_time
+    print_result = args.print_result
+    print_pretty = args.print_pretty
+
+    # create objects
+    mb = ModbusWrapper(logger=register_logger, quiet=not args.debug)
+
+    # open connection to device
+    result = mb.setup_connection(device_type=args.connection,
+                                 address=args.address,
+                                 port=port,
+                                 unit=unit,
+                                 baudrate=baudrate)
+    if result is False:
+        logger.error('Failed to setup connection with {device_type} device '
+                     'with bus ID {unit} at {address}:{port}'.
+                     format(device_type=args.connection,
+                            unit=unit,
+                            address=args.address,
+                            port=port))
+        exit(-1)
+
+    # open connection to device
+    mb.connect = True
+
+    # create and get the info dict
+    read_content = mb.read_all_registers(check_expectation=args.validate,
+                                         file=args.file,
+                                         sleep_time_sec=sleep_time)
+
+    now = helper.get_unix_timestamp()
+    timestring = helper.format_timestamp(timestamp=now,
+                                         format="%m-%d-%Y %H:%M:%S")
+    read_content['TIMESTAMP'] = timestring
+    logger.debug('Register content: {}'.format(read_content))
+
+    if save_info:
+        if output_file is not None:
+            # do not sort keys to get JSON file in same order as input file
+            result = mb.save_json_file(path=output_file,
+                                       content=read_content,
+                                       pretty=print_pretty,
+                                       sort_keys=False)
+            logger.debug('Result of saving info as JSON: {}'.format(result))
+        else:
+            logger.warning('Can not save to not specified file')
+
+    # do print as last step
+    if print_result:
+        # do not sort keys to get JSON file in same order as input file
+        if print_pretty:
+            print(json.dumps(read_content, indent=4))
+        else:
+            print(json.dumps(read_content))

--- a/src/be_modbus_wrapper/modbus_wrapper.py
+++ b/src/be_modbus_wrapper/modbus_wrapper.py
@@ -17,6 +17,7 @@ from pymodbus.client.sync import ModbusSerialClient     # as ModbusClient
 from pymodbus.constants import Endian
 from pymodbus.payload import BinaryPayloadDecoder
 import logging
+from time import sleep
 from typing import Tuple
 from typing import Union
 
@@ -301,7 +302,8 @@ class ModbusWrapper(ModuleHelper):
 
     def read_all_registers(self,
                            check_expectation: bool = False,
-                           file: str = 'modbusRegisters.json') -> dict:
+                           file: str = 'modbusRegisters.json',
+                           sleep_time_sec: int = 0) -> dict:
         """
         Read all modbus registers.
 
@@ -309,6 +311,8 @@ class ModbusWrapper(ModuleHelper):
         :type       check_expectation:  bool, optional
         :param      file:               The modbus register json file
         :type       file:               str, optional
+        :param      sleep_time_sec:     Sleep time between requests
+        :type       sleep_time_sec:     int, default 0
 
         :returns:   Dictionary with read register data
         :rtype:     dict
@@ -336,7 +340,8 @@ class ModbusWrapper(ModuleHelper):
         if 'COILS' in modbus_registers:
             invalid_counter, coil_register_content = self.read_coil_registers(
                 modbus_registers=modbus_registers['COILS'],
-                check_expectation=check_expectation)
+                check_expectation=check_expectation,
+                sleep_time_sec=sleep_time_sec)
             self.logger.debug('coil_register_content: {}'.
                               format(coil_register_content))
 
@@ -350,7 +355,8 @@ class ModbusWrapper(ModuleHelper):
         if 'HREGS' in modbus_registers:
             invalid_counter, hreg_register_content = self.read_hregs_registers(
                 modbus_registers=modbus_registers['HREGS'],
-                check_expectation=check_expectation)
+                check_expectation=check_expectation,
+                sleep_time_sec=sleep_time_sec)
             self.logger.debug('hreg_register_content: {}'.
                               format(hreg_register_content))
 
@@ -364,7 +370,8 @@ class ModbusWrapper(ModuleHelper):
         if 'ISTS' in modbus_registers:
             invalid_counter, ists_register_content = self.read_ists_registers(
                 modbus_registers=modbus_registers['ISTS'],
-                check_expectation=check_expectation)
+                check_expectation=check_expectation,
+                sleep_time_sec=sleep_time_sec)
             self.logger.debug('ists_register_content: {}'.
                               format(ists_register_content))
 
@@ -378,7 +385,8 @@ class ModbusWrapper(ModuleHelper):
         if 'IREGS' in modbus_registers:
             invalid_counter, ireg_register_content = self.read_iregs_registers(
                 modbus_registers=modbus_registers['IREGS'],
-                check_expectation=check_expectation)
+                check_expectation=check_expectation,
+                sleep_time_sec=sleep_time_sec)
             self.logger.debug('ireg_register_content: {}'.
                               format(ireg_register_content))
 
@@ -418,12 +426,16 @@ class ModbusWrapper(ModuleHelper):
         """
         self._read_content = value
 
-    def write_all_registers(self, file: str = 'modbusRegisters.json') -> dict:
+    def write_all_registers(self,
+                            file: str = 'modbusRegisters.json',
+                            sleep_time_sec: int = 0) -> dict:
         """
         Write all modbus registers.
 
-        :param      file:  The modbus register json file
-        :type       file:  str, optional
+        :param      file:           The modbus register json file
+        :type       file:           str, optional
+        :param      sleep_time_sec: Sleep time between requests
+        :type       sleep_time_sec: int, default 0
 
         :returns:   Dictionary with failed register write operations
         :rtype:     dict
@@ -450,7 +462,8 @@ class ModbusWrapper(ModuleHelper):
         self.logger.info('Coils:')
         if 'COILS' in modbus_registers:
             failed_counter, coil_register_log = self.write_coil_registers(
-                modbus_registers=modbus_registers['COILS'])
+                modbus_registers=modbus_registers['COILS'],
+                sleep_time_sec=sleep_time_sec)
             self.logger.debug('coil_register_log: {}'.
                               format(coil_register_log))
 
@@ -463,7 +476,8 @@ class ModbusWrapper(ModuleHelper):
         self.logger.info('Hregs:')
         if 'HREGS' in modbus_registers:
             failed_counter, hreg_register_log = self.write_hregs_registers(
-                modbus_registers=modbus_registers['HREGS'])
+                modbus_registers=modbus_registers['HREGS'],
+                sleep_time_sec=sleep_time_sec)
             self.logger.debug('hreg_register_log: {}'.
                               format(hreg_register_log))
 
@@ -492,7 +506,8 @@ class ModbusWrapper(ModuleHelper):
 
     def read_coil_registers(self,
                             modbus_registers: dict,
-                            check_expectation: bool) -> Tuple[int, dict]:
+                            check_expectation: bool,
+                            sleep_time_sec: int = 0) -> Tuple[int, dict]:
         """
         Read all coil registers.
 
@@ -502,6 +517,8 @@ class ModbusWrapper(ModuleHelper):
         :type       modbus_registers:   dict
         :param      check_expectation:  Flag to check expectation
         :type       check_expectation:  bool
+        :param      sleep_time_sec:     Sleep time between requests
+        :type       sleep_time_sec:     int, default 0
 
         :returns:   Amount of mismatching content and read content as dict
         :rtype:     tuple
@@ -549,10 +566,13 @@ class ModbusWrapper(ModuleHelper):
                                       format(bit_val, expected_val))
                     invalid_reg_counter += 1
 
+            sleep(sleep_time_sec)
+
         return invalid_reg_counter, register_content
 
     def write_coil_registers(self,
-                             modbus_registers: dict) -> Tuple[int, dict]:
+                             modbus_registers: dict,
+                             sleep_time_sec: int = 0) -> Tuple[int, dict]:
         """
         Write all coil registers.
 
@@ -560,6 +580,8 @@ class ModbusWrapper(ModuleHelper):
 
         :param      modbus_registers:   The modbus registers
         :type       modbus_registers:   dict
+        :param      sleep_time_sec:     Sleep time between requests
+        :type       sleep_time_sec:     int, default 0
 
         :returns:   Amount of failed content and failed registers as dict
         :rtype:     tuple
@@ -587,11 +609,14 @@ class ModbusWrapper(ModuleHelper):
                 self.logger.debug('\tSuccessfully set {} to {}'.
                                   format(key, set_val))
 
+            sleep(sleep_time_sec)
+
         return failed_reg_counter, failed_reg_log
 
     def read_hregs_registers(self,
                              modbus_registers: dict,
-                             check_expectation: bool) -> Tuple[int, dict]:
+                             check_expectation: bool,
+                             sleep_time_sec: int = 0) -> Tuple[int, dict]:
         """
         Read all holding registers.
 
@@ -601,6 +626,8 @@ class ModbusWrapper(ModuleHelper):
         :type       modbus_registers:   dict
         :param      check_expectation:  Flag to check expectation
         :type       check_expectation:  bool
+        :param      sleep_time_sec:     Sleep time between requests
+        :type       sleep_time_sec:     int, default 0
 
         :returns:   Amount of mismatching content and read content as dict
         :rtype:     tuple
@@ -677,10 +704,13 @@ class ModbusWrapper(ModuleHelper):
                                       format(register_val, expected_val))
                     invalid_reg_counter += 1
 
+            sleep(sleep_time_sec)
+
         return invalid_reg_counter, register_content
 
     def write_hregs_registers(self,
-                              modbus_registers: dict) -> Tuple[int, dict]:
+                              modbus_registers: dict,
+                              sleep_time_sec: int = 0) -> Tuple[int, dict]:
         """
         Write all holding registers.
 
@@ -688,6 +718,8 @@ class ModbusWrapper(ModuleHelper):
 
         :param      modbus_registers:   The modbus registers
         :type       modbus_registers:   dict
+        :param      sleep_time_sec:     Sleep time between requests
+        :type       sleep_time_sec:     int, default 0
 
         :returns:   Amount of failed content and failed registers as dict
         :rtype:     tuple
@@ -730,11 +762,14 @@ class ModbusWrapper(ModuleHelper):
                 self.logger.debug('Successfully set {} to {}'.
                                   format(register_address, set_val))
 
+            sleep(sleep_time_sec)
+
         return failed_reg_counter, failed_reg_log
 
     def read_ists_registers(self,
                             modbus_registers: dict,
-                            check_expectation: bool) -> Tuple[int, dict]:
+                            check_expectation: bool,
+                            sleep_time_sec: int = 0) -> Tuple[int, dict]:
         """
         Read all discrete input registers.
 
@@ -745,6 +780,8 @@ class ModbusWrapper(ModuleHelper):
         :type       modbus_registers:   dict
         :param      check_expectation:  Flag to check expectation
         :type       check_expectation:  bool
+        :param      sleep_time_sec:     Sleep time between requests
+        :type       sleep_time_sec:     int, default 0
 
         :returns:   Amount of mismatching content and read content as dict
         :rtype:     tuple
@@ -794,11 +831,14 @@ class ModbusWrapper(ModuleHelper):
                                       format(bit_val, expected_val))
                     invalid_reg_counter += 1
 
+            sleep(sleep_time_sec)
+
         return invalid_reg_counter, register_content
 
     def read_iregs_registers(self,
                              modbus_registers: dict,
-                             check_expectation: bool) -> Tuple[int, dict]:
+                             check_expectation: bool,
+                             sleep_time_sec: int = 0) -> Tuple[int, dict]:
         """
         Read all input registers.
 
@@ -808,6 +848,8 @@ class ModbusWrapper(ModuleHelper):
         :type       modbus_registers:   dict
         :param      check_expectation:  Flag to check expectation
         :type       check_expectation:  bool
+        :param      sleep_time_sec:     Sleep time between requests
+        :type       sleep_time_sec:     int, default 0
 
         :returns:   Amount of mismatching content and read content as dict
         :rtype:     tuple
@@ -885,5 +927,7 @@ class ModbusWrapper(ModuleHelper):
                     self.logger.error('\tValue {} not matching expectation {}'.
                                       format(register_val, expected_val))
                     invalid_reg_counter += 1
+
+            sleep(sleep_time_sec)
 
         return invalid_reg_counter, register_content


### PR DESCRIPTION
### Added
- Add [`read_device_info_registers`](examples/read_device_info_registers.py) script to read Modbus device data
- Specify sleep time in seconds between two modbus operations